### PR TITLE
+on-memory-write hook: nudge against memory rot

### DIFF
--- a/plugins/quick-review/.claude-plugin/plugin.json
+++ b/plugins/quick-review/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "quick-review",
-  "version": "0.5.335",
+  "version": "0.5.336",
   "description": "Auto-triggers a quick code review after git commits",
   "hooks": {
     "SessionStart": [
@@ -79,6 +79,10 @@
           {
             "type": "command",
             "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/check-comments.sh"
+          },
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/on-memory-write.sh"
           },
           {
             "type": "command",

--- a/plugins/quick-review/hooks/on-memory-write.sh
+++ b/plugins/quick-review/hooks/on-memory-write.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+source "$(dirname "$0")/lib-common.sh"
+require_jq_or_exit
+
+input=$(cat)
+file_path=$(echo "$input" | jq -r '.tool_input.file_path // .tool_input.p // ""')
+
+# Memory lives at ~/.claude/projects/<slug>/memory/
+[[ "$file_path" == *"/.claude/projects/"*"/memory/"* ]] || exit 0
+# Skip the index file: a single save also touches MEMORY.md, and we want one nudge
+[[ "$(basename "$file_path")" == "MEMORY.md" ]] && exit 0
+
+cat <<'EOF'
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PostToolUse",
+    "additionalContext": "This is an automated message for writing to memory: Please introspect — will this memory rot? For example: (1) TODOs go in GitHub issues instead. (2) Explanations about the code go in the repo, so all devs see + understand them."
+  }
+}
+EOF


### PR DESCRIPTION
👋 Claude here

Adds a `PostToolUse` hook that fires when Claude writes to memory (`~/.claude/projects/*/memory/`), mirroring the existing `check-comments.sh` nudge. Requested:

> any idea if we can make our plugin have a hook when claude writes to memory, similarly to our hook when claude writes to a comment?

The nudge (wording from the user):

> Please introspect, will this memory rot? for example: (1) TODOs go in github issues instead. (2) explanations about the code should go in the repo, so all devs will see+understand them

Notes:
- Memory writes are plain `Write`/`Edit` calls, so this slots into the existing `Edit|Write` `PostToolUse` block.
- Skips `MEMORY.md` (the index) so a single save = one nudge, not two.

🤖 Generated with [Claude Code](https://claude.com/claude-code)